### PR TITLE
Add embed color customization and jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # SlumBittyBum
+
+Economy Discord bot with customizable embed colors, a job system and more.

--- a/main.js
+++ b/main.js
@@ -1,4 +1,12 @@
-const { Client, GatewayIntentBits, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const {
+    Client,
+    GatewayIntentBits,
+    EmbedBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    StringSelectMenuBuilder,
+} = require('discord.js');
 const fs = require('fs');
 require('dotenv').config();
 
@@ -18,7 +26,14 @@ function saveData(data) {
 function getUserData(id) {
     const data = loadData();
     if (!data[id]) {
-        data[id] = { wallet: 0, inventory: {}, lastDaily: 0 };
+        data[id] = {
+            wallet: 0,
+            inventory: {},
+            lastDaily: 0,
+            color: 0x00ff99,
+            jobLevels: {},
+            currentJob: null,
+        };
         saveData(data);
     }
     return data[id];
@@ -30,11 +45,64 @@ function setUserData(id, userData) {
     saveData(data);
 }
 
+function getEmbedColor(user) {
+    if (!user || user.color === undefined) return 0x00ff99;
+    if (user.color === 'random') {
+        return Math.floor(Math.random() * 0xffffff);
+    }
+    return user.color;
+}
+
 const shopItems = {
     shovel: { price: 50, name: 'Shovel' },
     rifle: { price: 250, name: 'Hunting Rifle' },
     rod: { price: 100, name: 'Fishing Rod' },
 };
+
+const colorOptions = [
+    { label: 'Red', value: '16711680' },
+    { label: 'Green', value: '65280' },
+    { label: 'Blue', value: '255' },
+    { label: 'Yellow', value: '16776960' },
+    { label: 'Purple', value: '8388736' },
+    { label: 'Orange', value: '16753920' },
+    { label: 'White', value: '16777215' },
+    { label: 'Black', value: '0' },
+    { label: 'Random', value: 'random' },
+];
+
+const jobs = [
+    { id: 'farmer', name: 'Farmer' },
+    { id: 'miner', name: 'Miner' },
+    { id: 'fisherman', name: 'Fisherman' },
+    { id: 'hunter', name: 'Hunter' },
+    { id: 'woodcutter', name: 'Woodcutter' },
+    { id: 'blacksmith', name: 'Blacksmith' },
+    { id: 'alchemist', name: 'Alchemist' },
+    { id: 'merchant', name: 'Merchant' },
+    { id: 'engineer', name: 'Engineer' },
+    { id: 'scientist', name: 'Scientist' },
+    { id: 'pilot', name: 'Pilot' },
+    { id: 'astronaut', name: 'Astronaut' },
+    { id: 'ninja', name: 'Ninja' },
+    { id: 'wizard', name: 'Wizard' },
+    { id: 'legend', name: 'Legend' },
+];
+
+const commandInfo = [
+    { name: 'ping', description: 'Show bot latency', category: 'Utility' },
+    { name: 'wallet', description: 'Check your coin balance', category: 'Economy' },
+    { name: 'daily', description: 'Claim daily coins', category: 'Economy' },
+    { name: 'beg', description: 'Beg for coins', category: 'Economy' },
+    { name: 'dig', description: 'Dig for coins', category: 'Economy' },
+    { name: 'hunt', description: 'Hunt for coins', category: 'Economy' },
+    { name: 'fish', description: 'Fish for coins', category: 'Economy' },
+    { name: 'shop', description: 'View or buy shop items', category: 'Economy' },
+    { name: 'embedcolor', description: 'Change embed color', category: 'Utility' },
+    { name: 'job', description: 'Apply for a job', category: 'Jobs' },
+    { name: 'work', description: 'Work at your current job', category: 'Jobs' },
+    { name: 'help', description: 'Show this help message', category: 'Utility' },
+];
 
 const client = new Client({
     intents: [
@@ -61,9 +129,11 @@ client.on('messageCreate', async message => {
     if (command === 'ping') {
         const wsPing = Math.round(client.ws.ping);
         const ping = wsPing >= 0 ? wsPing : Date.now() - message.createdTimestamp;
+        const user = getUserData(message.author.id);
         const embed = new EmbedBuilder()
             .setTitle('Pong!')
             .setDescription(`Current latency: ${ping}ms`)
+            .setColor(getEmbedColor(user))
             .setFooter({ text: 'Clicks: 0' });
 
         const customId = `ping_${message.id}_${Date.now()}`;
@@ -81,7 +151,7 @@ client.on('messageCreate', async message => {
         const embed = new EmbedBuilder()
             .setTitle(`${message.author.username}'s Wallet`)
             .setDescription(`You have **${user.wallet}** coins.`)
-            .setColor(0x00ff99);
+            .setColor(getEmbedColor(user));
         await message.reply({ embeds: [embed] });
     } else if (command === 'daily') {
         const user = getUserData(message.author.id);
@@ -91,7 +161,7 @@ client.on('messageCreate', async message => {
             const embed = new EmbedBuilder()
                 .setTitle('Daily Reward')
                 .setDescription(`You already claimed your daily reward. Try again in about **${remaining}** hour(s).`)
-                .setColor(0xffcc00);
+                .setColor(getEmbedColor(user));
             await message.reply({ embeds: [embed] });
         } else {
             const amount = Math.floor(Math.random() * 100) + 100;
@@ -101,7 +171,7 @@ client.on('messageCreate', async message => {
             const embed = new EmbedBuilder()
                 .setTitle('Daily Reward')
                 .setDescription(`You collected **${amount}** coins!`)
-                .setColor(0x00ff99);
+                .setColor(getEmbedColor(user));
             await message.reply({ embeds: [embed] });
         }
     } else if (command === 'beg') {
@@ -112,7 +182,7 @@ client.on('messageCreate', async message => {
         const embed = new EmbedBuilder()
             .setTitle('Begging')
             .setDescription(`Someone felt generous and gave you **${amount}** coins.`)
-            .setColor(0x00ff99);
+            .setColor(getEmbedColor(user));
         await message.reply({ embeds: [embed] });
     } else if (['dig', 'hunt', 'fish'].includes(command)) {
         const user = getUserData(message.author.id);
@@ -133,7 +203,7 @@ client.on('messageCreate', async message => {
             const embed = new EmbedBuilder()
                 .setTitle('Missing Item')
                 .setDescription(`You need a **${shopItems[itemKey].name}** to start ${action}. Check the shop!`)
-                .setColor(0xff0000);
+                .setColor(getEmbedColor(user));
             await message.reply({ embeds: [embed] });
             return;
         }
@@ -144,7 +214,7 @@ client.on('messageCreate', async message => {
         const embed = new EmbedBuilder()
             .setTitle(`${action.charAt(0).toUpperCase() + action.slice(1)}`)
             .setDescription(`You earned **${amount}** coins by ${action}!`)
-            .setColor(0x00ff99);
+            .setColor(getEmbedColor(user));
         await message.reply({ embeds: [embed] });
     } else if (command === 'shop') {
         const user = getUserData(message.author.id);
@@ -155,7 +225,7 @@ client.on('messageCreate', async message => {
                 const embed = new EmbedBuilder()
                     .setTitle('Shop')
                     .setDescription('Item not found.')
-                    .setColor(0xff0000);
+                    .setColor(getEmbedColor(user));
                 await message.reply({ embeds: [embed] });
                 return;
             }
@@ -163,7 +233,7 @@ client.on('messageCreate', async message => {
                 const embed = new EmbedBuilder()
                     .setTitle('Shop')
                     .setDescription(`You don't have enough coins for a **${shopItem.name}**.`)
-                    .setColor(0xff0000);
+                    .setColor(getEmbedColor(user));
                 await message.reply({ embeds: [embed] });
                 return;
             }
@@ -173,7 +243,7 @@ client.on('messageCreate', async message => {
             const embed = new EmbedBuilder()
                 .setTitle('Shop')
                 .setDescription(`You bought a **${shopItem.name}** for **${shopItem.price}** coins.`)
-                .setColor(0x00ff99);
+                .setColor(getEmbedColor(user));
             await message.reply({ embeds: [embed] });
         } else {
             const desc = Object.entries(shopItems)
@@ -183,36 +253,123 @@ client.on('messageCreate', async message => {
                 .setTitle('Shop Items')
                 .setDescription(desc)
                 .setFooter({ text: `Use =shop buy <item>` })
-                .setColor(0x00ff99);
+                .setColor(getEmbedColor(user));
             await message.reply({ embeds: [embed] });
         }
+    } else if (command === 'embedcolor') {
+        const user = getUserData(message.author.id);
+        const menu = new StringSelectMenuBuilder()
+            .setCustomId(`embedcolor_${message.author.id}`)
+            .setPlaceholder('Select a color')
+            .addOptions(colorOptions);
+        const row = new ActionRowBuilder().addComponents(menu);
+        const embed = new EmbedBuilder()
+            .setTitle('Choose your embed color')
+            .setColor(getEmbedColor(user));
+        await message.reply({ embeds: [embed], components: [row] });
+    } else if (command === 'job') {
+        const user = getUserData(message.author.id);
+        const available = jobs.filter((j, i) => {
+            if (j.id === 'legend') {
+                return jobs.slice(0, -1).every(job => user.jobLevels[job.id] >= 100);
+            }
+            if (i === 0) return true;
+            const prev = jobs[i - 1];
+            return user.jobLevels[prev.id] >= 100;
+        });
+        const menu = new StringSelectMenuBuilder()
+            .setCustomId(`jobselect_${message.author.id}`)
+            .setPlaceholder('Select a job')
+            .addOptions(available.map(j => ({ label: j.name, value: j.id })));
+        const row = new ActionRowBuilder().addComponents(menu);
+        const embed = new EmbedBuilder()
+            .setTitle('Available Jobs')
+            .setColor(getEmbedColor(user));
+        await message.reply({ embeds: [embed], components: [row] });
+    } else if (command === 'work') {
+        const user = getUserData(message.author.id);
+        if (!user.currentJob) {
+            const embed = new EmbedBuilder()
+                .setTitle('Job')
+                .setDescription('Apply for a job first using =job')
+                .setColor(getEmbedColor(user));
+            await message.reply({ embeds: [embed] });
+        } else {
+            const level = user.jobLevels[user.currentJob] || 0;
+            if (level < 100) {
+                user.jobLevels[user.currentJob] = level + 1;
+            }
+            const amount = Math.floor(Math.random() * 50) + 20;
+            user.wallet += amount;
+            setUserData(message.author.id, user);
+            const embed = new EmbedBuilder()
+                .setTitle(`Working as ${jobs.find(j => j.id === user.currentJob).name}`)
+                .setDescription(`You earned **${amount}** coins. Job level: ${user.jobLevels[user.currentJob]}`)
+                .setColor(getEmbedColor(user));
+            await message.reply({ embeds: [embed] });
+        }
+    } else if (command === 'help') {
+        const user = getUserData(message.author.id);
+        const categories = {};
+        for (const info of commandInfo) {
+            if (!categories[info.category]) categories[info.category] = [];
+            categories[info.category].push(`**=${info.name}** - ${info.description}`);
+        }
+        const embed = new EmbedBuilder()
+            .setTitle('Help')
+            .setColor(getEmbedColor(user));
+        Object.keys(categories).sort().forEach(cat => {
+            embed.addFields({ name: cat, value: categories[cat].join('\n') });
+        });
+        await message.reply({ embeds: [embed] });
     }
 });
 
 client.on('interactionCreate', async interaction => {
-    if (!interaction.isButton()) return;
-    const { customId } = interaction;
-    if (!customId.startsWith('ping_')) return;
+    if (interaction.isButton()) {
+        const { customId } = interaction;
+        if (!customId.startsWith('ping_')) return;
+        let count = clickCounters.get(customId) || 0;
+        count += 1;
+        clickCounters.set(customId, count);
 
-    let count = clickCounters.get(customId) || 0;
-    count += 1;
-    clickCounters.set(customId, count);
+        const wsPing = Math.round(interaction.client.ws.ping);
+        const ping = wsPing >= 0 ? wsPing : Date.now() - interaction.createdTimestamp;
+        const user = getUserData(interaction.user.id);
+        const embed = new EmbedBuilder()
+            .setTitle('Pong!')
+            .setDescription(`Current latency: ${ping}ms`)
+            .setColor(getEmbedColor(user))
+            .setFooter({ text: `Clicks: ${count}` });
 
-    const wsPing = Math.round(interaction.client.ws.ping);
-    const ping = wsPing >= 0 ? wsPing : Date.now() - interaction.createdTimestamp;
-    const embed = new EmbedBuilder()
-        .setTitle('Pong!')
-        .setDescription(`Current latency: ${ping}ms`)
-        .setFooter({ text: `Clicks: ${count}` });
+        const button = new ButtonBuilder()
+            .setCustomId(customId)
+            .setLabel('🏓')
+            .setStyle(ButtonStyle.Primary);
 
-    const button = new ButtonBuilder()
-        .setCustomId(customId)
-        .setLabel('🏓')
-        .setStyle(ButtonStyle.Primary);
+        const row = new ActionRowBuilder().addComponents(button);
 
-    const row = new ActionRowBuilder().addComponents(button);
-
-    await interaction.update({ embeds: [embed], components: [row] });
+        await interaction.update({ embeds: [embed], components: [row] });
+    } else if (interaction.isStringSelectMenu()) {
+        const { customId, values } = interaction;
+        if (customId.startsWith('embedcolor_')) {
+            const user = getUserData(interaction.user.id);
+            const choice = values[0];
+            user.color = choice === 'random' ? 'random' : parseInt(choice, 10);
+            setUserData(interaction.user.id, user);
+            const label = colorOptions.find(o => o.value === choice)?.label || 'custom';
+            await interaction.reply({ content: `Embed color updated to ${label}` , ephemeral: true });
+        } else if (customId.startsWith('jobselect_')) {
+            const jobId = values[0];
+            const user = getUserData(interaction.user.id);
+            user.currentJob = jobId;
+            if (!user.jobLevels[jobId]) {
+                user.jobLevels[jobId] = 0;
+            }
+            setUserData(interaction.user.id, user);
+            await interaction.reply({ content: `You applied to ${jobs.find(j => j.id === jobId).name}!`, ephemeral: true });
+        }
+    }
 });
 
 client.login(process.env.DISCORD_TOKEN);


### PR DESCRIPTION
## Summary
- implement persistent embed color setting
- add jobs with sequential unlocks and work command
- add help command with dynamic categories
- update README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c1c66f58483249741d8d7befcdafd