### PR TITLE
Improve job command usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # SlumBittyBum
 
 Economy Discord bot with customizable embed colors, a job system and more.
+
+### Job Commands
+
+- `=job` &mdash; Shows a menu of available jobs.
+- `=job <job>` &mdash; Apply directly to a job by its id or name.
+- `=job list` works the same as `=job`.
+- `=work` &mdash; Earn coins based on your current job.


### PR DESCRIPTION
## Summary
- support typed `=job <job>` to apply directly for jobs
- update job help description and README docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c927bb3708324aba2044c3d839e9e