### PR TITLE
Add level and control commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Economy Discord bot with customizable embed colors, a job system and more.
 - `=job <job>` &mdash; Apply directly to a job by its id or name.
 - `=job list` works the same as `=job`.
 - `=work` &mdash; Earn coins based on your current job.
+- `=level` &mdash; View your current job level and unlocked jobs.


### PR DESCRIPTION
## Summary
- add job `=level` command
- allow admin item, level, and money adjustments via `=control`/`=givemoney`
- mention `=level` in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c96bbe7d48324b4ca60f7d096d3f9