### PR TITLE
Add loot system, inventory and lootboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ Economy Discord bot with customizable embed colors, a job system and more.
 - `=level` &mdash; View your current job level and unlocked jobs.
 - `=levelset <amount>` &mdash; Set the level of your current job.
 - `=levelsetall <amount>` &mdash; Set the level of all jobs.
+
+### Economy Commands
+
+- `=dig`, `=fish`, `=hunt` &mdash; Use tools to earn coins and random loot. Tools have limited durability.
+- `=shop` &mdash; View or buy items including new lootboxes.
+- `=inventory` &mdash; View items you own.
+- `=open <lootbox>` &mdash; Open a lootbox for coins and loot.
+- `=sell <item> [amount]` &mdash; Sell items from your inventory.


### PR DESCRIPTION
## Summary
- add durability-based tools and loot tables
- implement inventory, lootboxes and selling items
- update shop/admin controls for new items
- document new economy commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c9c622ec48324b62c5911e6dad7a9