### PR TITLE
Add webhook mode and update lootpool command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Economy Discord bot with customizable embed colors, a job system and more.
 - `=inventory` &mdash; View items you own.
 - `=open <basic|rare|epic>` &mdash; Open one of your lootboxes.
 - `=sell <item> [amount]` &mdash; Sell items from your inventory.
-- `=lootpool <command>` &mdash; Show the loot table for a command.
+- `=lootpool <command>` &mdash; Show the loot table for a command and possible coin rewards.


### PR DESCRIPTION
## Summary
- add new webhook-mode logic with helper functions
- allow customizing webhook avatar and name
- add webhook related commands to help info
- show possible coin rewards in `=lootpool` command
- document lootpool improvement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d3e930cf8832492723bedb911b3f7