### PR TITLE
Improve /math command parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ Economy Discord bot with customizable embed colors, a job system and more.
 - `=quest claim` &mdash; Claim quest rewards when finished.
 - `=timers` &mdash; Check cooldown timers like your daily reward.
 - `=trade <@user> <item> [amount]` &mdash; Send coins or items to another player.
-- `/math` &mdash; Slash command to solve or evaluate math expressions.
+- `/math` &mdash; Slash command to solve or evaluate math expressions. Supports
+  common words like `plus`, `minus`, `times`/`x`, and numbers written out (e.g.
+  `one plus two`).

--- a/main.js
+++ b/main.js
@@ -100,6 +100,38 @@ function getEmbedColor(user) {
     return user.color;
 }
 
+function normalizeExpression(expr) {
+    if (!expr) return '';
+    let out = expr.toLowerCase();
+    const numbers = {
+        zero: '0',
+        one: '1',
+        two: '2',
+        three: '3',
+        four: '4',
+        five: '5',
+        six: '6',
+        seven: '7',
+        eight: '8',
+        nine: '9',
+        ten: '10',
+    };
+    for (const [word, digit] of Object.entries(numbers)) {
+        const regex = new RegExp(`\\b${word}\\b`, 'g');
+        out = out.replace(regex, digit);
+    }
+    out = out
+        .replace(/plus/gi, '+')
+        .replace(/minus/gi, '-')
+        .replace(/(times|multiplied by|\bx\b)/gi, '*')
+        .replace(/(divided by|over)/gi, '/')
+        .replace(/(equals|equal to)/gi, '=')
+        .replace(/\s+/g, ' ');
+    // replace "x" used between numbers with *
+    out = out.replace(/(?<=\d)\s*x\s*(?=\d)/gi, '*');
+    return out.trim();
+}
+
 async function createUserWebhook(userId, channel) {
     const user = getUserData(userId);
     try {
@@ -998,7 +1030,8 @@ client.on('interactionCreate', async interaction => {
     if (interaction.isChatInputCommand()) {
         if (interaction.commandName === 'math') {
             const mode = interaction.options.getString('mode');
-            const expr = interaction.options.getString('expression');
+            const rawExpr = interaction.options.getString('expression');
+            const expr = normalizeExpression(rawExpr);
             const user = getUserData(interaction.user.id);
             const embed = new EmbedBuilder()
                 .setTitle('🧮 Math Solver')


### PR DESCRIPTION
## Summary
- support more natural language phrases in `/math` expressions
- document new math capabilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ea955a814832489362e720d52839c