### PR TITLE
Fix undefined result in math command

### DIFF
--- a/main.js
+++ b/main.js
@@ -1046,11 +1046,15 @@ client.on('interactionCreate', async interaction => {
                     steps = mathsteps.solveEquation(expr);
                     if (steps.length > 0) {
                         result = steps[steps.length - 1].newEquation.ascii();
+                    } else {
+                        result = expr;
                     }
                 } else if (mode === 'simplify') {
                     steps = mathsteps.simplifyExpression(expr);
                     if (steps.length > 0) {
                         result = steps[steps.length - 1].newNode.toString();
+                    } else {
+                        result = expr;
                     }
                 } else {
                     result = math.evaluate(expr).toString();


### PR DESCRIPTION
## Summary
- default to original expression when mathsteps returns no steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eacba17008324a628e374e7b4147e